### PR TITLE
Updated saveDebugScreenshots

### DIFF
--- a/src/GeneralUtils.js
+++ b/src/GeneralUtils.js
@@ -206,13 +206,5 @@
         return result;
     }
 
-    function _getTZOString(timezoneOffset){
-        var prefix = timezoneOffset > 0 ? '-' : '+';
-        var offsetHours = Math.abs(Math.floor(timezoneOffset/60));
-        var offsetMinutes = Math.abs(timezoneOffset%60);
-
-        return prefix + _numpad(offsetHours, 2) + _numpad(offsetMinutes, 2);
-    }
-
     module.exports = GeneralUtils;
 }());

--- a/src/ImageUtils.js
+++ b/src/ImageUtils.js
@@ -484,5 +484,24 @@
         });
     };
 
+    /**
+     *
+     * @param {Buffer} imageBuffer
+     * @param {string} filename
+     * @param {PromiseFactory} promiseFactory
+     * @return {Promise<void>}
+     */
+    ImageUtils.saveImage = function (imageBuffer, filename, promiseFactory) {
+        return promiseFactory.makePromise(function (resolve, reject) {
+            fs.writeFile(filename, imageBuffer, function(err) {
+                if(err) {
+                    reject(err);
+                }
+
+                resolve();
+            });
+        });
+    };
+
     module.exports = ImageUtils;
 }());

--- a/src/MutableImage.js
+++ b/src/MutableImage.js
@@ -226,16 +226,8 @@
      */
     MutableImage.prototype.saveImage = function (filename) {
         var that = this;
-        return this.asObject().then(function (imageObject) {
-            return that._promiseFactory.makePromise(function (resolve, reject) {
-                fs.writeFile(filename, imageObject.imageBuffer, function(err) {
-                    if(err) {
-                        reject(err);
-                    }
-
-                    resolve(that);
-                });
-            });
+        return that.asObject().then(function (imageObject) {
+            return ImageUtils.saveImage(imageObject.imageBuffer, filename, that._promiseFactory);
         });
     };
 


### PR DESCRIPTION
- removed 'tag' attribute from getScreenshot method
- added 'debugScreenshotsPath' attribute to getScreenshot method
- added new location for saveDebugScreenshot call
- 'saveImage' method moved from MutableImage to ImageUtils
- 'saveImage' method from MutableImage calls to ImageUtils