### PR TITLE
Remove buffers `noAssert` argument

### DIFF
--- a/src/ImageUtils.js
+++ b/src/ImageUtils.js
@@ -349,8 +349,8 @@
                 for (var x = 0; x < image.width; x++) {
                     for (var y = image.height - 1; y >= 0; y--) {
                         var idx = (image.width * y + x) << 2;
-                        var data = image.data.readUInt32BE(idx, true);
-                        buffer.writeUInt32BE(data, offset, true);
+                        var data = image.data.readUInt32BE(idx);
+                        buffer.writeUInt32BE(data, offset);
                         offset += 4;
                     }
                 }


### PR DESCRIPTION
Support for the `noAssert` argument dropped in the upcoming Node.js
v.10. This removes the argument to make sure everything works as it
should.

Refs: https://github.com/nodejs/node/pull/18395